### PR TITLE
Support for Asterisk 11

### DIFF
--- a/src/nami.js
+++ b/src/nami.js
@@ -45,7 +45,7 @@ function Nami(amiData) {
     this.amiData = amiData;
     this.EOL = "\r\n";
     this.EOM = this.EOL + this.EOL;
-    this.welcomeMessage = "Asterisk Call Manager/1.[12]" + this.EOL;
+    this.welcomeMessage = "Asterisk Call Manager/1.[123]" + this.EOL;
     this.received = false;
     this.responses = { };
     this.callbacks = { };


### PR DESCRIPTION
Asterisk 11 is using AMI 1.3.  This one line patch adds at least the beginning of compatibility.  Haven't verified 100% of functionality between 10 and 11, but thus far, it appears to work normally.
