### PR TITLE
Adds "onRawEventUnmarshalled" can specify AMI Login Events param

### DIFF
--- a/src/message/action.js
+++ b/src/message/action.js
@@ -52,14 +52,18 @@ var ActionUniqueId = (function() {
  * @constructor
  * @param {String} username The username. The value of the "Username" key.
  * @param {String} secret The password. The value of the "Secret" key.
+ * @param {String} a comma delimited list of Events to subscribe to.  Example: "call,hud" will subscribe to all call and hud events.
  * @see Action(String)
  * @see See <a href="https://wiki.asterisk.org/wiki/display/AST/ManagerAction_Login">https://wiki.asterisk.org/wiki/display/AST/ManagerAction_Login</a>.
  * @augments Action
  */
-function Login(username, secret) {
+function Login(username, secret, events) {
     Login.super_.call(this, 'Login');
     this.set('Username', username);
     this.set('Secret', secret );
+    if( events !== undefined ) {
+        this.set('Events', events);
+    }
 }
 /**
  * CoreShowChannels Action.

--- a/src/nami.js
+++ b/src/nami.js
@@ -128,6 +128,7 @@ Nami.prototype.onRawMessage = function (buffer) {
     if (buffer.match(/^Event: /) !== null) {
         event = new namiEvents.Event(buffer);
         this.emit('namiRawEvent', event);
+        this.emit('namiRawEventUnmarshalled', buffer); // This includes the raw event unmarshalled with \r\n etc still intact
     } else if (buffer.match(/^Response: /) !== null) {
         response = new namiResponse.Response(buffer);
         this.emit('namiRawResponse', response);
@@ -183,7 +184,7 @@ Nami.prototype.onClosed = function () {
  * On successfull connection, "namiConnected" is emitted.
  * @param {String} data The data read from server.
  * @see Nami#onData(String)
- * @see Login(String, String)
+ * @see Login(String, String, String)
  * @returns void
  */
 Nami.prototype.onWelcomeMessage = function (data) {
@@ -197,7 +198,7 @@ Nami.prototype.onWelcomeMessage = function (data) {
             self.onData(data);
         });
         this.send(
-            new action.Login(this.amiData.username, this.amiData.secret),
+            new action.Login(this.amiData.username, this.amiData.secret, this.amiData.events),
             function (response) {
                 if (response.response !== 'Success') {
                     self.emit('namiLoginIncorrect');


### PR DESCRIPTION
- onRawEventUnmarshalled - returns a string containing the event received.  Useful for logging purposes or if your code wants to log events from various phone systems in a universal format.
- Login(..) now takes an events param which is sent as part of the login message.  This can be used to limit the types of events you receive.  For example, "call,hud" is good for retrieving just call events.
