### PR TITLE
Conference Actions

### DIFF
--- a/src/message/message.js
+++ b/src/message/message.js
@@ -30,6 +30,7 @@
 function Message() {
     this.lines = [];
     this.EOL = "\r\n";
+    this.variables = {};
 }
 
 /**
@@ -41,11 +42,17 @@ function Message() {
 Message.prototype.marshall = function () {
     var output = "", key;
     for (key in this) {
+        if (key === 'variables') {
+            continue;
+        }
         if (this.hasOwnProperty(key)) {
             if (key !== 'lines' && key !== 'EOL' && (typeof (this[key]) !== 'function')) {
                 output = output + key + ": " + this[key] + this.EOL;
             }
         }
+    }
+    for (key in this.variables) {
+        output = output + 'Variable: ' + key + '=' + this.variables[key] + this.EOL;
     }
     output = output + this.EOL;
     return output;
@@ -61,30 +68,28 @@ Message.prototype.unmarshall = function (data) {
     var value, parts, key, line = 0;
     this.lines = data.split(this.EOL);
     for (; line < this.lines.length; line = line + 1) {
-        if(this.lines[line].indexOf("--END COMMAND--") != -1){
-          key = "CommandOutput";
-          value = this.lines[line].replace("--END COMMAND--", "");
-        } else {
-            parts = this.lines[line].split(":");
-            key = parts.shift();
-            /*
-             * This is so, because if this message is a response, specifically a response to
-             * something like "ListCommands", the value of the keys, can contain the semicolon
-             * ":", which happens to be token to be used to split keys and values. AMI does not
-             * specify anything like an escape character, so we cant distinguish wether we're
-             * dealing with a multi semicolon line or a standard key/value line.
-             */
-            if (parts.length > 1) {
-                value = parts.join(':');
-            } else if (parts.length === 1) {
-                value = parts[0];
-            }
+        parts = this.lines[line].split(":");
+        key = parts.shift();
+        /*
+         * This is so, because if this message is a response, specifically a response to
+         * something like "ListCommands", the value of the keys, can contain the semicolon
+         * ":", which happens to be token to be used to split keys and values. AMI does not
+         * specify anything like an escape character, so we cant distinguish wether we're
+         * dealing with a multi semicolon line or a standard key/value line.
+         */
+        if (parts.length > 1) {
+            value = parts.join(':');
+        } else if (parts.length === 1) {
+            value = parts[0];
         }
-
-        this.set(
-            key.replace(/-/, '_').toLowerCase(),
-            value.replace(/^\s+/g, '').replace(/\s+$/g, '')
-        );
+        var keySafe = key.replace(/-/, '_').toLowerCase();
+        var valueSafe = value.replace(/^\s+/g, '').replace(/\s+$/g, '');
+        if (keySafe.match(/variable/) !== null) {
+            var variable = valueSafe.split("=");
+            this.variables[variable[0]] = variable[1];
+        } else {
+            this.set(keySafe, valueSafe);
+        }
     }
 };
 


### PR DESCRIPTION
Get information from the asterisk about running conferences.

Indeed this is a little more complicated. Based on the build-in modules
of your asterisk it is possible that MeetMe - Conferences aren't supported (they are deprecated anyway)
- or - 

if your asterisk is too old you won't be able to use the confbridge commands.
But if everthing works as usual you should get an error response for using an unknown command.

I'm looking for a more intuitive way to avoid sending unknown commands in the future. But
at this moment i just want to add the missing actions.
