### PR TITLE
Removed log4js dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,18 +127,19 @@ That's about it.
 
 Using logger other than console
 ------------------------------
-Nami constructor takes an optional parameter, which may contain 'logger'
-attribute. If it exists, it will be used instead of console:
+Nami config may contain an optional attribute 'logger'.
+If it exists, it will be used instead of console:
 
 ```js
-var nami = new (require("nami").Nami)(namiConfig, {logger: require('log4js').getLogger('Nami.Core')});
+namiConfig.logger = require('log4js').getLogger('Nami.Core');
+var nami = new (require("nami").Nami)(namiConfig);
 ```
 
 Viable options:
 https://github.com/nomiddlename/log4js-node
 https://github.com/trentm/node-bunyan
 
-Anything that can be looks like:
+Logger may be anything that can be looks like:
 ```
 logger = {
     error: function(message) {},

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ events.
 Requirements
 ------------
  * Nodejs (Tested with 0.6.5)
- * log4js (For logging, tested with 0.3.9)
 
 Events used in Nami
 -------------------
@@ -63,7 +62,6 @@ received message as a response to an action.
 Installation
 ------------
 ```sh
-$ npm install log4js
 $ npm install nami
 ```
 
@@ -86,7 +84,6 @@ Quickstart
 ```sh
 $ mkdir testnami
 $ cd testnami
-$ npm install log4js
 $ npm install nami
 ```
 ```js
@@ -127,6 +124,29 @@ See src/index.js for a better example (including how to reconnect when the
 current connection closes).
 
 That's about it.
+
+Using logger other than console
+------------------------------
+Nami constructor takes an optional parameter, which may contain 'logger'
+attribute. If it exists, it will be used instead of console:
+
+```js
+var nami = new (require("nami").Nami)(namiConfig, {logger: require('log4js').getLogger('Nami.Core')});
+```
+
+Viable options:
+https://github.com/nomiddlename/log4js-node
+https://github.com/trentm/node-bunyan
+
+Anything that can be looks like:
+```
+logger = {
+    error: function(message) {},
+    warn : function(message) {},
+    info : function(message) {},
+    debug: function(message) {},
+}
+```
 
 Multiple server support
 -----------------------

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "test": "index"
   },
   "engines" : { "node" : ">=0.6.5" },
-  "dependencies": {
-    "log4js": "0.3.9"
-  },
+  "dependencies": {},
   "devDependencies": {}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -27,10 +27,11 @@ var namiConfig = {
     host: process.argv[2],
     port: process.argv[3],
     username: process.argv[4],
-    secret: process.argv[5]
+    secret: process.argv[5],
+    logger: require("log4js").getLogger('Nami.Core')
 };
 
-var nami = new namiLib.Nami(namiConfig, {logger: require("log4js").getLogger('Nami.Core')});
+var nami = new namiLib.Nami(namiConfig);
 process.on('SIGINT', function () {
     nami.close();
     process.exit();

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ var namiConfig = {
     secret: process.argv[5]
 };
 
-var nami = new namiLib.Nami(namiConfig);
+var nami = new namiLib.Nami(namiConfig, {logger: require("log4js").getLogger('Nami.Core')});
 process.on('SIGINT', function () {
     nami.close();
     process.exit();

--- a/src/nami.js
+++ b/src/nami.js
@@ -36,13 +36,11 @@ var timer = require('timers');
  * Nami client.
  * @constructor
  * @param {object} amiData The configuration for ami.
- * @param {object} options Optional object which may contain library settings
  * @augments EventEmitter
  */
-function Nami(amiData, options) {
+function Nami(amiData) {
     Nami.super_.call(this);
-    options = options || {};
-    this.logger = options.logger || console;
+    this.logger = amiData.logger || console;
     this.connected = false;
     this.amiData = amiData;
     this.EOL = "\r\n";

--- a/src/nami.js
+++ b/src/nami.js
@@ -40,7 +40,7 @@ var timer = require('timers');
  */
 function Nami(amiData) {
     Nami.super_.call(this);
-    this.logger = amiData.logger || console;
+    this.logger = amiData.logger || defaultLoggger();
     this.connected = false;
     this.amiData = amiData;
     this.EOL = "\r\n";
@@ -55,6 +55,18 @@ function Nami(amiData) {
 }
 // Nami inherits from the EventEmitter so Nami itself can throw events.
 util.inherits(Nami, events.EventEmitter);
+
+/**
+ * Constructs default logger for this library
+ */
+function defaultLoggger() {
+    return {
+        error: console.error.bind(console),
+        warn : console.warn.bind(console),
+        info : console.info.bind(console),
+        debug: console.log.bind(console)
+    };
+}
 
 /**
  * Called when a message arrives and is decoded as an event (namiRawEvent event).

--- a/src/nami.js
+++ b/src/nami.js
@@ -35,12 +35,14 @@ var timer = require('timers');
 /**
  * Nami client.
  * @constructor
- * @param amiData The configuration for ami.
+ * @param {object} amiData The configuration for ami.
+ * @param {object} options Optional object which may contain library settings
  * @augments EventEmitter
  */
-function Nami(amiData) {
+function Nami(amiData, options) {
     Nami.super_.call(this);
-    this.logger = require('log4js').getLogger('Nami.Client');
+    options = options || {};
+    this.logger = options.logger || console;
     this.connected = false;
     this.amiData = amiData;
     this.EOL = "\r\n";


### PR DESCRIPTION
Changes:
  * log4js is no longer added as npm dependency
  * default logger is 'console' object
  * logger injection can be done during initialization, or later as:
       
        nami.logger = mostAmazingLogger;