### PR TITLE
Dropped strict requiremet for asterisk AMI version.

### DIFF
--- a/src/nami.js
+++ b/src/nami.js
@@ -45,7 +45,7 @@ function Nami(amiData) {
     this.amiData = amiData;
     this.EOL = "\r\n";
     this.EOM = this.EOL + this.EOL;
-    this.welcomeMessage = "Asterisk Call Manager/1.[123]" + this.EOL;
+    this.welcomeMessage = "Asterisk Call Manager/.*" + this.EOL;
     this.received = false;
     this.responses = { };
     this.callbacks = { };


### PR DESCRIPTION
This enables support for asterisk 12, which reports
`"Asterisk Call Manager/2.3.0"`
