### PR TITLE
Add support for AMI BlindTransfer Action

### DIFF
--- a/src/message/action.js
+++ b/src/message/action.js
@@ -1061,6 +1061,23 @@ function AGI(channel, command, commandId) {
   this.set('CommandID', commandId);
 }
 
+/**
+ * BlindTransfer Action.
+ * @constructor
+ * @see Action(String)
+ * @see https://wiki.asterisk.org/wiki/display/AST/Asterisk+12+ManagerAction_BlindTransfer
+ * @param {String} Source channel that wants to transfer the target channel.
+ * @param {String} Context to transfer the target channel to.
+ * @param {String} Extension inside the context to transfer the target channel to.
+ * @augments Action
+ */
+function BlindTransfer(channel, context, extension) {
+  BlindTransfer.super_.call(this, 'BlindTransfer');
+  this.set('Channel', channel);
+  this.set('Context', context);
+  this.set('Exten', extension);
+}
+
 // Inheritance for this module
 util.inherits(Action, message.Message);
 (function() {
@@ -1143,7 +1160,8 @@ util.inherits(Action, message.Message);
         ConfbridgeUnlock,
         ConfbridgeMute,
         ConfbridgeUnmute,
-        AGI 
+        AGI,
+        BlindTransfer
     ];
     for (i in actions) {
         util.inherits(actions[i], Action);


### PR DESCRIPTION
This pull request adds support for BlindTransfer, an AMI action that allows the connected channel to be transferred to another context/extension within the dial plan. To use this, you must call it like so:

``` javascript
new namiLib.Actions.BlindTransfer('channel', 'context', 'extension');
```

The channel that is referred to in the parameters is not the channel to be transferred, rather the channel that wants to do the transferring. For example, an Agent is connected to a caller, and he wants to transfer that caller to another context/extension, you have to pass in the Agent's channel name.
