### PR TITLE
Updated API for QueuePause and QueueUnpaused

### DIFF
--- a/src/message/action.js
+++ b/src/message/action.js
@@ -783,9 +783,18 @@ function Queues() {
  * @property {String} Reason Optional, reason description
  * @augments Action
  */
-function QueueUnpause() {
-	QueueUnpause.super_.call(this, 'QueueUnpause');
-    this.paused = 'false';
+function QueueUnpause(interface, queue) {
+  	QueueUnpause.super_.call(this, 'QueuePause');
+  this.set('paused', 'false');
+  this.set('interface', interface);
+    
+  if (undefined !== queue) {
+    this.set('queue', queue);
+  }
+  
+  if (undefined !== reason) {
+    this.set('reason', reason);
+  }
 }
 
 /**
@@ -798,9 +807,18 @@ function QueueUnpause() {
  * @property {String} Reason Optional, reason description
  * @augments Action
  */
-function QueuePause() {
+function QueuePause(interface, queue, reason) {
 	QueuePause.super_.call(this, 'QueuePause');
-    this.paused = 'true';
+  this.set('paused', 'true');
+  this.set('interface', interface);
+    
+  if (undefined !== queue) {
+    this.set('queue', queue);
+  }
+  
+  if (undefined !== reason) {
+    this.set('reason', reason);
+  }
 }
 
 /**


### PR DESCRIPTION
I have updated the API for QueuePause and QueueUnpause to allow parameter injection rather than messing with the internal instance properties. This is safer, as someone could forget to instantiate the Action, which would result in the context referred to inside the action being the global scope rather than the instance. 

I also fixed a bug where QueueUnpause() would send 'QueueUnpause' as an action, rather than 'QueuePause' with paused = false.
