### PR TITLE
VarSet: Nami should not chomp on all 'Variable:' keys

### DIFF
--- a/src/message/message.js
+++ b/src/message/message.js
@@ -84,7 +84,10 @@ Message.prototype.unmarshall = function (data) {
         }
         var keySafe = key.replace(/-/, '_').toLowerCase();
         var valueSafe = value.replace(/^\s+/g, '').replace(/\s+$/g, '');
-        if (keySafe.match(/variable/) !== null) {
+        /*
+         * SetVar contains Variable: header, but value should not include '=' in this case
+         */
+        if (keySafe.match(/variable/) !== null && valueSafe.match(/=/) !== null) {
             var variable = valueSafe.split("=");
             this.variables[variable[0]] = variable[1];
         } else {


### PR DESCRIPTION
Previously Nami chomped all lines containing 'variable' in the key and tried
to fill `variables` hash with `KEY=VALUE` pairs from that.
Unfortunately Asterisk has this one command, where

```
Variable: KEY
Value: VALUE
```

https://wiki.asterisk.org/wiki/display/AST/Asterisk+11+ManagerEvent_VarSet

To avoid this I added additional check to distinguish VarSet syntax from other
commands and events.