### PR TITLE
Controlar los level log

### DIFF
--- a/src/nami.js
+++ b/src/nami.js
@@ -41,6 +41,9 @@ var timer = require('timers');
 function Nami(amiData) {
     Nami.super_.call(this);
     this.logger = require('log4js').getLogger('Nami.Client');
+    if (amiData.loglevel){
+        this.logger.setLevel(amiData.loglevel);
+    }
     this.connected = false;
     this.amiData = amiData;
     this.EOL = "\r\n";


### PR DESCRIPTION
Se agrega para luego poder usar en el archivo de configuración la variable de log

var namiConfig = {
    host: demo,
    port: demo,
    username: demo,
    secret: demo,
    loglevel: "fatal"
};