### PR TITLE
Allow masking events on Login when opening the connection

### DIFF
--- a/src/nami.js
+++ b/src/nami.js
@@ -209,8 +209,12 @@ Nami.prototype.onWelcomeMessage = function (data) {
         this.socket.on('data', function (data) {
             self.onData(data);
         });
+        var login = new action.Login(this.amiData.username, this.amiData.secret)
+        if (Array.isArray(this.amiData.events)) {
+            login.set('Events', events.join(','))
+        }
         this.send(
-            new action.Login(this.amiData.username, this.amiData.secret),
+            login,
             function (response) {
                 if (response.response !== 'Success') {
                     self.emit('namiLoginIncorrect');

--- a/src/nami.js
+++ b/src/nami.js
@@ -211,7 +211,7 @@ Nami.prototype.onWelcomeMessage = function (data) {
         });
         var login = new action.Login(this.amiData.username, this.amiData.secret)
         if (Array.isArray(this.amiData.events)) {
-            login.set('Events', events.join(','))
+            login.set('Events', this.amiData.events.join(','))
         }
         this.send(
             login,


### PR DESCRIPTION
I have an Asterisk instance that generates a great amount of events. The manager is configured to authorize all events:

```ini
read = system,call,log,verbose,agent,user,config,dtmf,reporting,cdr,dialplan
write = system,call,agent,user,config,command,reporting,originate,message
```

My application connects using the Asterisk Management Interface (AMI) but at startup I don't want to be flooded by all events generated by Asterisk. I want to be able to select which events should be transmitted.

Using the [Events](https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+ManagerAction_Events) command I can decide which events should be transmitted. Unfortunately from the moment I login until the moment I submit this command my application is flooded by events.

A [non-documented feature](https://github.com/asterisk/asterisk/blob/2fac32a37adbe92922212e17f2989cf1b0333832/main/manager.c#L3493) of the login action allows us to set the event mask that we are interested in at Login.

This pull request allows you to pass an array of events:

```js
var namiConfig = {
    host: process.argv[2],
    port: process.argv[3],
    username: process.argv[4],
    secret: process.argv[5],
    events: ['system', 'call']
};

var nami = new namiLib.Nami(namiConfig);
```

When the events option is omitted Nami does not set the event mask on the login action.

Similar to #13 but less intrusive.
